### PR TITLE
Removed updated_at from datum, now delegates to the root document

### DIFF
--- a/app/models/datum.rb
+++ b/app/models/datum.rb
@@ -2,11 +2,8 @@ class Datum
   include MongoMapper::EmbeddedDocument
   include Porthos::DatumMethods
 
-  key :updated_at, Time
   key :datum_template_id, ObjectId
   key :active, Boolean, :default => lambda { true }
-
-  before_save :set_timestamps
 
   def root_embedded_document
     @root_embedded_document ||= _parent_document == _root_document ? self : _parent_document.try(:root_embedded_document)
@@ -16,9 +13,8 @@ class Datum
     @is_root ||= self == root_embedded_document
   end
 
-  def update_attributes(*args)
-    update_timestamps
-    super(*args)
+  def updated_at
+    _root_document.try(:updated_at)
   end
 
   class << self
@@ -27,16 +23,6 @@ class Datum
         field.attributes = template.shared_attributes
       end
     end
-  end
-
-private
-
-  def set_timestamps
-    update_timestamps if self.updated_at.nil?
-  end
-
-  def update_timestamps
-    self.updated_at = Time.now.utc
   end
 
 end

--- a/test/unit/datum_test.rb
+++ b/test/unit/datum_test.rb
@@ -46,45 +46,14 @@ class DatumTest < ActiveSupport::TestCase
     refute decendant.is_root?
   end
 
-  test "sets updated_at when created" do
-    page = Factory.create(:page, :data => [Factory.build(:datum_collection, :handle => 'article')])
+  test "delegates updated_at to its root document" do
+    page = Factory.create(:page, :data => [])
     child = Factory.build(:string_field)
     page.data << child
 
-    assert child.updated_at.nil?, 'sanity check that updated_at is nil'
-
     page.save
 
-    refute child.updated_at.nil?
-    assert child.updated_at.is_a?(Time)
-  end
-
-  test "sets updated_at when using update attributes" do
-    page = Factory.create(:page, :data => [Factory.build(:datum_collection, :handle => 'article')])
-    child = Factory.build(:string_field)
-    page.data << child
-    page.save
-
-    last_timestamp = child.updated_at
-    last_cache_key = child.cache_key
-    sleep(1) # mongomapper does not save milliseconds
-
-    child.update_attributes(value: 'A value')
-
-    refute_equal child.cache_key, last_cache_key, 'should have a new cache key'
-    assert child.updated_at > last_timestamp, 'should have increased the updated_at'
-  end
-
-  test "does not update updated_at when parent is saved in another context" do
-    page = Factory.create(:page, :data => [Factory.build(:datum_collection, :handle => 'article')])
-    child = Factory.build(:string_field)
-    page.data << child
-    page.save
-
-    last_timestamp = child.updated_at
-    page.update_attributes(title: 'A new title')
-
-    assert_equal last_timestamp, child.updated_at, 'should not have increased the updated_at'
+    assert_equal page.updated_at, child.updated_at
   end
 
 end


### PR DESCRIPTION
I do not see any reason for embedded documents to have their own timestamps since the root document always (well almost always) will get updated at the same time. If we start doing atomic updates on embedded docs we can bump the root timestamp just as well.

The code we had seemed to mainly be about making cache key working for datum, which should work just as well when delegating to the root doc.
