### PR TITLE
Routes refactor

### DIFF
--- a/lib/porthos.rb
+++ b/lib/porthos.rb
@@ -41,6 +41,7 @@ module Porthos
     autoload :Rule,      'porthos/routing/rule'
     autoload :Rules,     'porthos/routing/rules'
     autoload :Recognize, 'porthos/routing/recognize'
+    autoload :Resolver,  'porthos/routing/resolver'
     autoload :Filters,   'porthos/routing/filters'
   end
 

--- a/lib/porthos/routing/filters.rb
+++ b/lib/porthos/routing/filters.rb
@@ -1,58 +1,11 @@
 require 'routing_filter'
+require 'porthos/routing/inject_find_routes_filter'
+
 module Porthos
   module Routing
     module Filters
 
       class UrlResolver < RoutingFilter::Filter
-        def around_recognize(path, env, &block)
-          excluded_path_prefixes = /(assets|admin|javascripts|stylesheets|images|graphics)/
-          if env["REQUEST_URI"] =~ excluded_path_prefixes or path =~ excluded_path_prefixes
-            return yield
-          end
-           
-          params = {}
-
-          path.replace URI.unescape(path)
-          matched_rule_params = {}
-          url = path.dup.gsub(/^\//,'')
-          format = File.extname(path)
-          url.gsub!(format, '') unless format.blank?
-          url << '/' if url.blank? # The root node has a single slash as url
-          
-          node = Node.where(url: url).first
-          unless node
-            Porthos::Routing::Recognize.run(path).each do |match|
-              next unless url.start_with?(match[:url])
-              if node = Node.where(url: match.delete(:url)).first
-                matched_rule_params = match
-                break
-              end
-            end
-            if node && node.handle && namespaced_match = Porthos::Routing::Recognize.run(path, :namespace => node.handle).first
-              params.merge!(namespaced_match)
-            elsif matched_rule_params.any?
-              params.merge!(matched_rule_params)
-            end
-          end
-
-          if node
-            params[:handle] = node.handle if node.handle.present?
-            params[:node] = { id: node.id, url: node.url }
-
-            # Update the env path to match rails routes
-            path_parts = [
-              node.controller,
-              node.action,
-              (node.action != 'index' ? node.resource_id : nil),
-              format
-            ]
-            path.replace('/' + path_parts.reject(&:blank?).reject { |part| %w(index show).include?(part) }.join('/'))
-          end
-
-          yield.tap do |p|
-            p.merge!(params)
-          end
-        end
 
         def around_generate(params, &block)
           if ! params[:controller].present? || params[:controller] =~ /admin/

--- a/lib/porthos/routing/inject_find_routes_filter.rb
+++ b/lib/porthos/routing/inject_find_routes_filter.rb
@@ -1,0 +1,23 @@
+Journey::Router.class_eval do
+  def find_routes_with_resolver env
+    path, filter_parameters = env['PATH_INFO'], {}
+    matches = find_routes_without_filtering(env)
+
+    if matches.empty?
+      excluded_path_prefixes = /(assets|admin|javascripts|stylesheets|images|graphics)/
+        unless env["REQUEST_URI"] =~ excluded_path_prefixes or path =~ excluded_path_prefixes
+          if route = Porthos::Routing::Resolver.new(path)
+            path.replace(route.path) if route.path
+            filter_parameters.merge!(route.params)
+          end
+
+          matches = find_routes_without_filtering(env).map do |match, parameters, route|
+            [ match, parameters.merge(filter_parameters), route ]
+          end
+        end
+    end
+
+    matches
+  end
+  alias_method :find_routes, :find_routes_with_resolver # reset routing-filtes aliasing
+end

--- a/lib/porthos/routing/resolver.rb
+++ b/lib/porthos/routing/resolver.rb
@@ -1,0 +1,96 @@
+module Porthos
+  module Routing
+    class Resolver
+      attr_reader :request_path, :params, :path
+
+      def initialize(path)
+        @request_path = CGI::unescape(path) # needs CGI::unescape to remove + characters
+        @node_by_url_cache = {}
+        resolve
+      end
+
+      def resolve
+        if node = node_by_url(path_as_url)
+          @params = node_params(node)
+        else
+          node, @params = recognize_path
+        end
+
+        if @params.any?
+          if node
+            @path = '/' + path_parts(node, format).join('/')
+            @params[:node] = { id: node.id, url: node.url }
+          end
+          @params.delete(:url) # we don't want url in returned params
+        end
+      end
+
+      private
+
+      def path_as_url
+        url = request_path.gsub(/^\//,'').gsub(/#{format}$/, '')
+          url << '/' if url.blank?
+        url
+      end
+
+      def format
+        @format ||= File.extname(request_path)
+      end
+
+      def node_by_url(url)
+        return @node_by_url_cache[url] if @node_by_url_cache[url]
+        @node_by_url_cache[url] = Node.where(url: url).first
+      end
+
+      def recognize_path
+        node = nil
+        path_params = {}
+        matched_rule = match_path
+
+        if matched_rule && node = node_by_url(matched_rule[:url])
+          if node.handle && namespaced_match = Porthos::Routing::Recognize.run(request_path, :namespace => node.handle).first
+            path_params = node_params(node).merge(namespaced_match)
+          else
+            path_params = node ? node_params(node).merge(matched_rule) : matched_rule
+          end
+        end
+
+        [node, path_params]
+      end
+
+      def match_path
+        matched_rule = nil
+        url = path_as_url
+
+        Porthos::Routing::Recognize.run(request_path).each do |match|
+          next unless url.start_with?(match[:url])
+          matched_rule = match
+          if node_by_url(match[:url])
+            break
+          end
+        end
+
+        matched_rule
+      end
+
+      def path_parts(node, format)
+        [
+          node.controller,
+          node.action,
+          (node.action != 'index' ? node.resource_id : nil),
+          format
+        ].reject(&:blank?).reject { |part| %w(index show).include?(part) }
+      end
+
+      def node_params(node)
+        {}.tap do |_hash|
+          _hash[:handle] = node.handle if node.handle.present?
+          _hash[:node] = { id: node.id, url: node.url }
+          _hash[:controller] = node.controller
+          _hash[:action] = node.action
+        end
+      end
+
+    end
+  end
+end

--- a/lib/porthos/routing/rules.rb
+++ b/lib/porthos/routing/rules.rb
@@ -56,7 +56,7 @@ module Porthos
       end
 
       def sorted
-       sort_by { |r| (r.constraints ? r.constraints.keys.size : 0)+r.path.size }.reverse
+       sort_by { |r| (r.constraints ? r.constraints.keys.size : 0)+r.path.size+r.prefix.to_s.size }.reverse
       end
 
       def find_matching_params(params)


### PR DESCRIPTION
Extracted routes recognition to its own class to make it more readable/testable (no tests included... ). 
- Removed use of routing-filter gem for route recognition
- New class named Resolver to handle route recognition 
- Added injection of Resolver class to Journey
- Fixes to make recognition work with rails 3.2
