### PR TITLE
Use page template as cache key for it's pages

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -18,7 +18,6 @@ class Page < Section
   key :position, Integer
 
   before_create :move_to_list_bottom
-  after_save :touch_section
 
   scope :with_page_template, lambda { |page_template_id|
     where(:page_template_id => page_template_id)
@@ -165,7 +164,4 @@ private
     index_node && (index_node.restricted? || index_node.ancestors.detect { |n| n.restricted? })
   end
 
-  def touch_section
-    Section.set({ page_template_id: self.page_template_id }, { updated_at: self.updated_at.utc })
-  end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,5 +1,6 @@
 class Section < Item
   key :page_template_id, ObjectId
+  key :association_ids, Array, typecast: 'ObjectId'
 
   tankit Porthos.config.tanking.index_name do
     indexes :title
@@ -8,7 +9,7 @@ class Section < Item
     indexes :data
   end
 
-  belongs_to :page_template
+  belongs_to :page_template, touch: true
 
   acts_as_uri :title,
               :target => :uri,
@@ -18,13 +19,42 @@ class Section < Item
   delegate :template,
            :to => :page_template
 
+  before_save :store_association_ids
+  after_save :touch_associations
+
   class << self
     def from_template(template, attributes = {})
-      self.new(attributes.merge(:page_template_id => template.id))
+      self.new attributes.merge(page_template_id: template.id)
     end
   end
 
   def can_have_a_node?
     false
+  end
+
+  private
+
+  def store_association_ids
+    self.association_ids = find_association_ids
+  end
+
+  def touch_associations
+    # Touch items associated to us
+    Item.where(association_ids: self.id).each &:touch
+  end
+
+  def find_association_ids(source = nil)
+    collection = source || self.data
+    result = []
+
+    collection.find_all { |d| d.active? }.each do |d|
+      if d.respond_to?(:page_id)
+        result << d.page_id
+      elsif d.respond_to?(:data) && d.data.any?
+        result += find_association_ids(d.data)
+      end
+    end
+
+    result.compact.uniq
   end
 end

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -4,6 +4,7 @@ class Template
   key :label, String
   key :description, String
   key :position, Integer
+  timestamps!
 
   many :datum_templates, :order => 'position asc' do
     def [](handle)

--- a/test/unit/item_test.rb
+++ b/test/unit/item_test.rb
@@ -26,42 +26,4 @@ class ItemTest < ActiveSupport::TestCase
     @item.valid?
     assert_equal 'A title with spaces', @item.title
   end
-
-  should 'find all association ids' do
-    @item.data = [
-      PageAssociation.new(:page_id => 1, :active => true),
-      DatumCollection.new({
-        :data => [
-          PageAssociation.new(:page_id => 2, :active => true),
-          PageAssociation.new(:page_id => 3, :active => false)
-        ],
-        :active => true
-      }),
-      PageAssociation.new(:page_id => 4, :active => true)
-    ]
-      
-    assert_equal [1, 2, 4], @item.send(:find_association_ids)
-  end
-
-  context 'with associations to other items' do
-    setup do
-      @another_item = FactoryGirl.create(:item)
-      @item.data << PageAssociation.new(:page_id => @another_item.id, :active => true)
-    end
-
-    should 'persist association ids' do
-      assert_equal [], @item.association_ids
-      @item.save
-      assert_equal [@another_item.id], @item.association_ids
-    end
-     
-    should 'touch associated items' do
-      @item.save
-      def @another_item.updated_at
-        Time.local(2009, 8, 15, 14, 0, 0)
-      end
-      @another_item.update_attribute(:title, 'I am Void')
-      assert_equal @another_item.updated_at, @item.reload.updated_at
-    end
-  end
 end

--- a/test/unit/page_test.rb
+++ b/test/unit/page_test.rb
@@ -57,18 +57,6 @@ class PageTest < ActiveSupport::TestCase
       assert_equal @section, @page.section
       assert_equal @page_template.section, @page.section
     end
-
-    should 'touch its section when updated' do
-
-      def @page.updated_at
-        Time.local(2009, 8, 15, 14, 0, 0).utc
-      end
-
-      @page.update_attribute(:title, 'Wow! I am updated')
-      assert_equal Time.local(2009, 8, 15, 14, 0, 0).utc, @page.updated_at
-      assert_equal Time.local(2009, 8, 15, 14, 0, 0).utc, @section.reload.updated_at
-    end
-
   end
 
   context 'when sortable' do

--- a/test/unit/section_test.rb
+++ b/test/unit/section_test.rb
@@ -1,0 +1,47 @@
+require_relative '../test_helper'
+
+class SectionTest < ActiveSupport::TestCase
+  setup do
+    @section = FactoryGirl.build(:section)
+  end
+
+  should 'find all association ids' do
+    @section.data = [
+      PageAssociation.new(:page_id => 1, :active => true),
+      DatumCollection.new({
+        :data => [
+          PageAssociation.new(:page_id => 2, :active => true),
+          PageAssociation.new(:page_id => 3, :active => false)
+        ],
+        :active => true
+      }),
+      PageAssociation.new(:page_id => 4, :active => true)
+    ]
+
+    assert_equal [1, 2, 4], @section.send(:find_association_ids)
+  end
+
+  context 'with associations to other items' do
+    setup do
+      @section.page_template = FactoryGirl.create :page_template
+      @page = FactoryGirl.create(:page)
+      def @page.updated_at
+        Time.local(2009, 8, 15, 14, 0, 0)
+      end
+      @section.data << PageAssociation.new(:page_id => @page.id, :active => true)
+    end
+
+    should 'persist association ids' do
+      assert_equal [], @section.association_ids
+      @section.save
+      assert_equal [@page.id], @section.association_ids
+    end
+
+    should 'touch associated items' do
+      @section.save
+      @section.expects(:touch).once
+
+      @page.update_attribute(:title, 'I am Void')
+    end
+  end
+end


### PR DESCRIPTION
Removes touching the section when updating pages.
Adds touch for page template associations.

Instead sections and items touches their page template when updated and
hence should the page template be used when caching collections of
pages.

This makes it easier to keep track on invalidation of caches.

ping @arvida @lexi 
