### PR TITLE
Fix sorting in admin/nodes#index

### DIFF
--- a/app/controllers/admin/content_templates_controller.rb
+++ b/app/controllers/admin/content_templates_controller.rb
@@ -46,11 +46,11 @@ class Admin::ContentTemplatesController < ApplicationController
 
   def sort
     params[:content_template].each_with_index do |id, i|
-      ContentTemplate.set(id, :position => i+1)
+      object_id = BSON::ObjectId.from_string id
+      ContentTemplate.set(object_id, position: i+1)
     end if params[:content_template]
-    respond_to do |format|
-      format.js { render :nothing => true }
-    end
+
+    render nothing: true
   end
 
 end

--- a/app/controllers/admin/nodes_controller.rb
+++ b/app/controllers/admin/nodes_controller.rb
@@ -106,9 +106,11 @@ class Admin::NodesController < ApplicationController
 
   def sort
     params[:node].each_with_index do |id, i|
-      Node.set(id, :position => i+1)
+      object_id = BSON::ObjectId.from_string id
+      Node.set(object_id, position: i+1)
     end
-    render :nothing => true
+
+    render nothing: true
   end
 
 end

--- a/app/controllers/admin/page_templates_controller.rb
+++ b/app/controllers/admin/page_templates_controller.rb
@@ -46,11 +46,11 @@ class Admin::PageTemplatesController < ApplicationController
 
   def sort
     params[:page_template].each_with_index do |id, i|
-      PageTemplate.set(id, :position => i+1)
+      object_id = BSON::ObjectId.from_string id
+      PageTemplate.set(object_id, position: i+1)
     end if params[:page_template]
-    respond_to do |format|
-      format.js { render :nothing => true }
-    end
+
+    render nothing: true
   end
 
 end


### PR DESCRIPTION
MongoMapper requires a real object id when performing set operations.
This also fixes sorting for content templates and page templates.

ping @arvida 
