### PR TITLE
Caching shell objects touches it shell on touch

### DIFF
--- a/lib/caching_shell/shelled.rb
+++ b/lib/caching_shell/shelled.rb
@@ -4,6 +4,7 @@ module CachingShell
 
     included do
       after_save :touch_shell
+      after_touch :touch_shell
     end
 
     def shell


### PR DESCRIPTION
This resolves a bug discovered in the Unicef project
(https://trello.com/c/QFo9R6vA): a object that belongs to a parent object
that includes CachingShell didn't update the parents cache key when the child object
touched the parent.
