### PR TITLE
Allow paths to include ”admin”

### DIFF
--- a/lib/porthos/routing/inject_find_routes_filter.rb
+++ b/lib/porthos/routing/inject_find_routes_filter.rb
@@ -1,11 +1,11 @@
 Journey::Router.class_eval do
   def find_routes_with_resolver env
-    path, filter_parameters = env['PATH_INFO'], {}
+    path, filter_parameters = env["PATH_INFO"], {}
     matches = find_routes_without_filtering(env)
 
     if matches.empty?
-      excluded_path_prefixes = /(assets|admin|javascripts|stylesheets|images|graphics)/
-      if !(env["REQUEST_URI"] =~ excluded_path_prefixes) || !(path =~ excluded_path_prefixes)
+      excluded_path_prefixes = %w[/assets /admin /javascripts /stylesheets /images /graphics]
+      if !path.starts_with?(*excluded_path_prefixes)
         if route = Porthos::Routing::Resolver.new(path)
           path.replace(route.path) if route.path
           filter_parameters.merge!(route.params)


### PR DESCRIPTION
This should fix the problems with urls that contain ”admin”.

Not sure why we also checked REQUEST_URI, from what I understand we should be able to rely on PATH_INFO. I removed it, test passes and everything looks to be working when deployed to staging. 

ping @joeljunstrom 
